### PR TITLE
Fix potential problem for training

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -480,7 +480,7 @@ def check_accuracy(args, program_generator, execution_engine, baseline_model, lo
     if num_samples >= args.num_val_samples:
       break
 
-  set_mode('eval', [program_generator, execution_engine, baseline_model])
+  set_mode('train', [program_generator, execution_engine, baseline_model])
   acc = float(num_correct) / num_samples
   return acc
 


### PR DESCRIPTION
Hi, 

It seems like that there is a potential bug in function `check_accuracy`.

This function is called periodically during training to monitor train/val accuracy of VQA models. And at each time, `set_mode('eval', ...)` is called to set model into ***validate*** mode. (Change behaviors for layers such as dropout, batchnorm, etc.). 

However, in its original version, it seems to forget setting model back to ***train*** mode ( by call `set_mode('train', ...)` ) after evaluation, which might cause problems for learning models that have batch-norm or dropout.

Best,